### PR TITLE
Bumped dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,14 @@ edition = "2018"
 
 [dependencies]
 chrono = "0.4"
-futures-lite = "1.11"
-egui = "0.12"
-epi = "0.12"
-egui_wgpu_backend = "0.8"
-egui_winit_platform = "0.7"
-wgpu = "0.8"
-winit = "0.24"
-egui_demo_lib = "0.12"
+futures-lite = "1.12"
+egui = "0.13"
+epi = "0.13"
+egui_wgpu_backend = "0.10"
+egui_winit_platform = "0.9"
+wgpu = "0.9"
+winit = "0.25"
+egui_demo_lib = "0.13"
 
 [patch.crates-io]
 # egui = { version = "0.5", git = "https://github.com/emilk/egui" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ fn main() {
     });
 
     // We use the egui_wgpu_backend crate as the render backend.
-    let mut egui_rpass = RenderPass::new(&device, OUTPUT_FORMAT);
+    let mut egui_rpass = RenderPass::new(&device, OUTPUT_FORMAT, 1);
 
     // Display the demo application that ships with egui.
     let mut demo_app = egui_demo_lib::WrapApp::default();
@@ -121,6 +121,7 @@ fn main() {
                         cpu_usage: previous_frame_time,
                         seconds_since_midnight: Some(seconds_since_midnight()),
                         native_pixels_per_point: Some(window.scale_factor() as _),
+                        prefer_dark_mode: None,
                     },
                     tex_allocator: &mut egui_rpass,
                     output: &mut app_output,


### PR DESCRIPTION
I've been referring to this example a lot recently, but I keep having to manually update to the latest versions of `wgpu`, `winit` and `egui`!

Here's just a simple PR that updates them all (and the rest of the dependencies) to their latest versions and modifies the source where necessary :grin: