### PR TITLE
Don't take `device` and `queue` mutably in `update_buffers`.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@ fn main() {
                 };
                 egui_rpass.update_texture(&device, &queue, &platform.context().texture());
                 egui_rpass.update_user_textures(&device, &queue);
-                egui_rpass.update_buffers(&mut device, &mut queue, &paint_jobs, &screen_descriptor);
+                egui_rpass.update_buffers(&device, &queue, &paint_jobs, &screen_descriptor);
 
                 // Record all render passes.
                 egui_rpass


### PR DESCRIPTION
`update_buffers` can take an `&device` and an `&queue` so taking them mutably is not needed and confusing for readers