### PR TITLE
Update dependencies and fix minimize on Windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-egui_wgpu_backend = "0.13"
+egui_wgpu_backend = "0.14"
 chrono = "0.4"
 pollster = "0.2"
-egui = "0.14"
-epi = "0.14"
-egui_winit_platform = "0.10.0"
+egui = "0.15"
+epi = "0.15"
+egui_winit_platform = "0.12"
 wgpu = "0.11"
-winit = "0.25"
-egui_demo_lib = "0.14"
+winit = "0.26"
+egui_demo_lib = "0.15"
 
 [patch.crates-io]
 # egui = { version = "0.5", git = "https://github.com/emilk/egui" }


### PR DESCRIPTION
This PR also changes the wgpu present mode to `Fifo` to enforce frame rate limiting. I was seeing more than 1800 fps on my machine with "continuous mode" enabled in the backend panel when `Mailbox` was used. Pretty snappy, but not very efficient.