### PR TITLE
Update deps and replace FrameBuilder to epi::backend::FrameData

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-egui_wgpu_backend = "0.14"
+egui_wgpu_backend = "0.16"
 chrono = "0.4"
 pollster = "0.2"
-egui = "0.15"
-epi = "0.15"
-egui_winit_platform = "0.12"
-wgpu = "0.11"
+egui = "0.16"
+epi = "0.16"
+egui_winit_platform = "0.13"
+wgpu = "0.12"
 winit = "0.26"
-egui_demo_lib = "0.15"
+egui_demo_lib = "0.16"
 
 [patch.crates-io]
 # egui = { version = "0.5", git = "https://github.com/emilk/egui" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ enum Event {
 /// It sends the custom RequestRedraw event to the winit event loop.
 struct ExampleRepaintSignal(std::sync::Mutex<winit::event_loop::EventLoopProxy<Event>>);
 
-impl epi::RepaintSignal for ExampleRepaintSignal {
+impl epi::backend::RepaintSignal for ExampleRepaintSignal {
     fn request_repaint(&self) {
         self.0.lock().unwrap().send_event(Event::RequestRedraw).ok();
     }
@@ -122,9 +122,9 @@ fn main() {
                 // Begin to draw the UI frame.
                 let egui_start = Instant::now();
                 platform.begin_frame();
-                let mut app_output = epi::backend::AppOutput::default();
+                let app_output = epi::backend::AppOutput::default();
 
-                let mut frame = epi::backend::FrameBuilder {
+                let mut frame =  epi::Frame::new(epi::backend::FrameData {
                     info: epi::IntegrationInfo {
                         name: "egui_example",
                         web_info: None,
@@ -132,11 +132,9 @@ fn main() {
                         native_pixels_per_point: Some(window.scale_factor() as _),
                         prefer_dark_mode: None,
                     },
-                    tex_allocator: &mut egui_rpass,
-                    output: &mut app_output,
+                    output: app_output,
                     repaint_signal: repaint_signal.clone(),
-                }
-                .build();
+                });
 
                 // Draw the demo application.
                 demo_app.update(&platform.context(), &mut frame);
@@ -158,7 +156,7 @@ fn main() {
                     physical_height: surface_config.height,
                     scale_factor: window.scale_factor() as f32,
                 };
-                egui_rpass.update_texture(&device, &queue, &platform.context().texture());
+                egui_rpass.update_texture(&device, &queue, &platform.context().font_image());
                 egui_rpass.update_user_textures(&device, &queue);
                 egui_rpass.update_buffers(&device, &queue, &paint_jobs, &screen_descriptor);
 


### PR DESCRIPTION
This PR updated the dependencies and tried to update code related https://github.com/hasenbanck/egui_wgpu_backend/pull/51, but there seems to be a problem with the texture allocator with egui_demo_lib/apps/color_test :
```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Internal("user texture 0 not found")', src/main.rs:172:22
stack backtrace:
   0: rust_begin_unwind
             at /rustc/f1ce0e6a00593493a12e0e3662119786c761f375/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /rustc/f1ce0e6a00593493a12e0e3662119786c761f375/library/core/src/panicking.rs:107:14
   2: core::result::unwrap_failed
             at /rustc/f1ce0e6a00593493a12e0e3662119786c761f375/library/core/src/result.rs:1690:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/f1ce0e6a00593493a12e0e3662119786c761f375/library/core/src/result.rs:1018:23
   4: egui_example::main::{{closure}}
             at ./src/main.rs:164:17
   5: winit::platform_impl::platform::sticky_exit_callback
             at .cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.26.1/src/platform_impl/linux/mod.rs:753:5
   6: winit::platform_impl::platform::x11::EventLoop<T>::run_return
             at .cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.26.1/src/platform_impl/linux/x11/mod.rs:310:21
   7: winit::platform_impl::platform::x11::EventLoop<T>::run
             at .cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.26.1/src/platform_impl/linux/x11/mod.rs:392:9
   8: winit::platform_impl::platform::EventLoop<T>::run
             at .cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.26.1/src/platform_impl/linux/mod.rs:669:56
   9: winit::event_loop::EventLoop<T>::run
             at .cargo/registry/src/github.com-1ecc6299db9ec823/winit-0.26.1/src/event_loop.rs:154:9
  10: egui_example::main
             at ./src/main.rs:97:5
  11: core::ops::function::FnOnce::call_once
             at /rustc/f1ce0e6a00593493a12e0e3662119786c761f375/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```
although i don't need this feature currently, I noticed that mesh.texture_id (Egui) https://github.com/hasenbanck/egui_wgpu_backend/blob/master/src/lib.rs#L348 come user (0) when I click on color test. 