### PR TITLE
Make the example more like an actual use case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,12 @@ resolver = "2"
 
 [dependencies]
 egui_wgpu_backend = "0.16"
-chrono = "0.4"
 pollster = "0.2"
 egui = "0.16"
 epi = "0.16"
 egui_winit_platform = "0.13"
 wgpu = "0.12"
 winit = "0.26"
-egui_demo_lib = "0.16"
 
 [patch.crates-io]
 # egui = { version = "0.5", git = "https://github.com/emilk/egui" }


### PR DESCRIPTION
I found the example confusing for just adding a GUI to my app. The things related to the full egui demo were unnecessary in my case and they made it harder to just add a simple GUI.