### PR TITLE
Update to 0.17, use official winit backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-egui_wgpu_backend = "0.16"
+egui_wgpu_backend = "0.17"
 chrono = "0.4"
 pollster = "0.2"
-egui = "0.16"
-epi = "0.16"
-egui_winit_platform = "0.13"
+egui = "0.17"
+epi = "0.17"
+egui-winit = "0.17"
 wgpu = "0.12"
 winit = "0.26"
-egui_demo_lib = "0.16"
+egui_demo_lib = "0.17"
 
 [patch.crates-io]
 # egui = { version = "0.5", git = "https://github.com/emilk/egui" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,7 @@ use std::iter;
 use std::time::Instant;
 
 use chrono::Timelike;
-use egui::FontDefinitions;
 use egui_wgpu_backend::{RenderPass, ScreenDescriptor};
-use egui_winit_platform::{Platform, PlatformDescriptor};
 use epi::*;
 use winit::event::Event::*;
 use winit::event_loop::ControlFlow;
@@ -78,13 +76,8 @@ fn main() {
     )));
 
     // We use the egui_winit_platform crate as the platform.
-    let mut platform = Platform::new(PlatformDescriptor {
-        physical_width: size.width as u32,
-        physical_height: size.height as u32,
-        scale_factor: window.scale_factor(),
-        font_definitions: FontDefinitions::default(),
-        style: Default::default(),
-    });
+    let mut state = egui_winit::State::new(4096, &window);
+    let context = egui::Context::default();
 
     // We use the egui_wgpu_backend crate as the render backend.
     let mut egui_rpass = RenderPass::new(&device, surface_format, 1);
@@ -92,16 +85,11 @@ fn main() {
     // Display the demo application that ships with egui.
     let mut demo_app = egui_demo_lib::WrapApp::default();
 
-    let start_time = Instant::now();
     let mut previous_frame_time = None;
     event_loop.run(move |event, _, control_flow| {
-        // Pass the winit events to the platform integration.
-        platform.handle_event(&event);
 
         match event {
             RedrawRequested(..) => {
-                platform.update_time(start_time.elapsed().as_secs_f64());
-
                 let output_frame = match surface.get_current_texture() {
                     Ok(frame) => frame,
                     Err(wgpu::SurfaceError::Outdated) => {
@@ -121,10 +109,11 @@ fn main() {
 
                 // Begin to draw the UI frame.
                 let egui_start = Instant::now();
-                platform.begin_frame();
+                let input = state.take_egui_input(&window);
+                context.begin_frame(input);
                 let app_output = epi::backend::AppOutput::default();
 
-                let mut frame =  epi::Frame::new(epi::backend::FrameData {
+                let frame =  epi::Frame::new(epi::backend::FrameData {
                     info: epi::IntegrationInfo {
                         name: "egui_example",
                         web_info: None,
@@ -137,11 +126,11 @@ fn main() {
                 });
 
                 // Draw the demo application.
-                demo_app.update(&platform.context(), &mut frame);
+                demo_app.update(&context, &frame);
 
                 // End the UI frame. We could now handle the output and draw the UI with the backend.
-                let (_output, paint_commands) = platform.end_frame(Some(&window));
-                let paint_jobs = platform.context().tessellate(paint_commands);
+                let output = context.end_frame();
+                let paint_jobs = context.tessellate(output.shapes);
 
                 let frame_time = (Instant::now() - egui_start).as_secs_f64() as f32;
                 previous_frame_time = Some(frame_time);
@@ -156,8 +145,9 @@ fn main() {
                     physical_height: surface_config.height,
                     scale_factor: window.scale_factor() as f32,
                 };
-                egui_rpass.update_texture(&device, &queue, &platform.context().font_image());
-                egui_rpass.update_user_textures(&device, &queue);
+
+                egui_rpass.add_textures(&device, &queue, &output.textures_delta).unwrap();
+                egui_rpass.remove_textures(output.textures_delta).unwrap();
                 egui_rpass.update_buffers(&device, &queue, &paint_jobs, &screen_descriptor);
 
                 // Record all render passes.
@@ -200,7 +190,10 @@ fn main() {
                 winit::event::WindowEvent::CloseRequested => {
                     *control_flow = ControlFlow::Exit;
                 }
-                _ => {}
+                event => {
+                    // Pass the winit events to the platform integration.
+                    state.on_event(&context, &event);
+                }
             },
             _ => (),
         }


### PR DESCRIPTION
- update this example to use egui_wgpu_backend 0.17 (from 0.16),
- change the egui_winit_platform winit backend to the official [egui-winit](https://github.com/emilk/egui/tree/master/egui-winit) backend. 

I believe it's better to use the official backend in this example and create a different example for the egui_winit_platform crate (or deprecate the crate entirely in favor of a single implementation in the ecosystem, especially that both crates are very similar).
I also believe that this example should live inside the egui_wgpu_backend repo (as a cargo example in a /examples folder).
Discussion is welcome.